### PR TITLE
UI cleanup

### DIFF
--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/css/fhstyle.css
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/css/fhstyle.css
@@ -1,16 +1,8 @@
 ﻿/*##################################*/
 /* F.A.L.M. Housekeeping Stylesheet */
 /*##################################*/
-#falm-header h3.title {
-    color: darkblue !important;
-}
-#falm-content h2.title {
-    font-size: 28px !important;
-    color: darkblue !important;
-}
-#falm-content .description {
-    margin-top: 40px !important;
-    margin-bottom: 20px !important;
+#falm-content .panel {
+    margin-top: 20px;
 }
 #falm-content .infoBox {
     margin-top: 40px !important;
@@ -18,11 +10,6 @@
 }
 #falm-content .infoBox .title {
     font-weight: bold;
-    font-style: italic;
-    border-bottom: double;
-}
-#falm-content .infoBox .text {
-    font-size: 12px;
 }
 #falm-content #infoTable {
     margin-top: 30px;
@@ -53,9 +40,6 @@
 }
 
 /* TABLE LOG */
-#falm-content #FHLogTable tbody tr {
-    font-size: 0.8em;
-}
 #falm-content #FHLogTable tbody td {
     min-width: 20px;
 }
@@ -73,11 +57,6 @@
 }
 
 /* TABLE VERSIONS */
-#falm-content #FHVersionsTable tbody tr,
-#falm-content #FHVersionFiltersTable tbody tr {
-    font-size: 0.8em;
-}
-
 #falm-content #FHVersionsTable tbody td,
 #falm-content #FHVersionFiltersTable tbody td {
     min-width: 20px;
@@ -88,18 +67,9 @@
     background-color: #f5f5f5;
 }
 
-#falm-content #FHVersionsTable thead th label {
-    font-size: 1em;
-}
-
-#falm-content #FHVersionFiltersTable thead th label {
-    font-size: 0.9em;
-}
-
 /* PAGINATION */
 #falm-content .pagination-total-pages {
     float: right;
-    color: #337ab7;
     font-weight: bold;
     margin: 30px 0;
 }

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/dashboard.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/dashboard.html
@@ -11,19 +11,21 @@
     <umb-panel>
         <umb-content id="falm-content">
             <div class="umb-panel-body no-header umb-scrollable with-footer" style="padding: 0 20px;">
-                <h2 class="title"><localize key="FALM_Dashboard.Title">F.A.L.M.</localize></h2>
+                <h3 class="title"><localize key="FALM_Dashboard.Title">F.A.L.M.</localize></h3>
                 <div class="subtitle"><localize key="FALM_Dashboard.SubTitle">Welcome to new generation of our cleaning tools totally rewrite using AngularJS and Bootstrap and now in a Custom Section.</localize></div>
                 <div class="description">
                     <localize key="FALM_Dashboard.Description"><p>This package adds a new section with the following tools:</p><ul><li><strong>Umbraco logs manager</strong>: with this tool you can view and delete Umbraco log events.<br />Now you can manage DB Log and the TraceLog (this is a simplified version of <a href="https://our.umbraco.org/projects/developer-tools/diplo-trace-log-viewer/" target="_blank">Diplo Trace Log Viewer</a> project)</li><li><strong>Media folder cleanup</strong>: with this tool you can delete those file system folders under '/media' which have no entry in the DB (orphans)</li><li><strong>Delete users manager</strong>: with this tool you can completely remove Umbraco users.</li><li><strong>Version manager</strong>: with this tool you can view and cleanup the version history that Umbraco mantains for each content node.</li></ul></localize>
                 </div>
                 <div class="infoBox">
-                    <localize key="FALM_Dashboard.LatestChanges"><p><span class="title">Latest Changes</span></p>
+                    <localize key="FALM_Dashboard.LatestChanges">
+                        <h4 class="title">Latest Changes</h4>
                         <p class="text">v7.6.0.0 - New version: totally rewrite using AngularJS and Bootstrap and now in a Custom Section. Fixed SQLCE compatibility (Not yet for Versions manager)</p>
                         <p class="text">v7.0.0.1 - Bug Fix: Resolved Error 404 when click all main headers (Logs, Media, Users, Versions) and resolved conflict in Users Manager</p>
                     </localize>
                 </div>
                 <div class="infoBox">
-                    <localize key="FALM_Dashboard.VersionHistory"><p><span class="title">Version History</span></p>
+                    <localize key="FALM_Dashboard.VersionHistory">
+                        <h4 class="title">Version History</h4>
                         <p class="text">v7.6.0.0 - Umbraco v7.5+</p>
                         <p class="text">v7.0.0.1 - Umbraco v7+</p>
                         <p class="text">v6.1.3.0 - Umbraco v6 to v7.2</p>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-dbmanager-modal-details.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-dbmanager-modal-details.html
@@ -1,9 +1,9 @@
 ﻿<umb-panel ng-controller="FALMHousekeepingLogsDBManagerDetailsController">
     <div class="umb-panel-header" id="falm-header">
-        <h3 class="title"><localize key="FALM_LogsManager.DBLogsDialog-Title">Event details</localize> (<strong>Id: {{ dialogData.logItem.LogId }}</strong>)</h3>
+        <h3 class="title"><localize key="FALM_LogsManager.DBLogsDialog-Title">Event details</localize> (<span>Id: {{ dialogData.logItem.LogId }}</span>)</h3>
     </div>
     <div class="umb-panel-body with-header with-footer" id="falm-content">
-        <table id="FHLogDetailTable" class="table" style="">
+        <table id="FHLogDetailTable" class="table">
             <tbody style="font-size: 12px;">
                 <tr>
                     <th style="padding: 15px; border-top: 0; width: 120px;"><localize key="FALM_LogsManager.DBLogsDialog-Event">Event</localize></th>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-dbmanager.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-dbmanager.html
@@ -13,7 +13,7 @@
         </umb-header>
         <umb-content id="falm-content">
             <div class="umb-panel-body with-header umb-scrollable no-footer" style="padding: 0 20px; margin-top: 19px;">
-                <h2 class="title"><localize key="FALM_LogsManager.Title_DB">Umbraco Logs Manager (DB)</localize></h2>
+                <h3 class="title"><localize key="FALM_LogsManager.Title_DB">Umbraco Logs Manager (DB)</localize></h3>
                 <div class="description">
                     <localize key="FALM_LogsManager.Description_DB">With this tool you can manage Umbraco DB log events.</localize>
                 </div>
@@ -24,7 +24,7 @@
                             <umb-load-indicator></umb-load-indicator>
                         </div>
                         
-                        <div ng-hide="!logs.ListDBLogs.length" class="panel panel-primary">
+                        <div ng-hide="!logs.ListDBLogs.length" class="panel panel-default">
                             <div class="panel-heading">
                                 <localize key="FALM_LogsManager.DBLogsPanelTitle">DB Log</localize> <localize key="FALM_LogsManager.Contains">contains</localize> <span class="badge">{{ filteredLogs.length }}</span> <localize key="FALM_LogsManager.Events">events</localize>
                             </div>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-tlmanager-modal-details.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-tlmanager-modal-details.html
@@ -3,7 +3,7 @@
         <h3 class="title"><localize key="FALM_LogsManager.DBLogsDialog-Title">Event details</localize></h3>
     </div>
     <div class="umb-panel-body with-header with-footer" id="falm-content">
-        <table id="FHLogDetailTable" class="table" style="">
+        <table id="FHLogDetailTable" class="table">
             <tbody style="font-size: 12px;">
                 <tr>
                     <th style="padding: 15px; border-top: 0; width: 120px;"><localize key="FALM_LogsManager.TraceLogsDialog-Event">Event</localize></th>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-tlmanager.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/logs-tlmanager.html
@@ -13,7 +13,7 @@
         </umb-header>
         <umb-content id="falm-content">
             <div class="umb-panel-body with-header umb-scrollable no-footer" style="padding: 0 20px; margin-top: 19px;">
-                <h2 class="title"><localize key="FALM_LogsManager.Title_TL">Umbraco Logs Manager (Trace Log)</localize></h2>
+                <h3 class="title"><localize key="FALM_LogsManager.Title_TL">Umbraco Logs Manager (Trace Log)</localize></h3>
                 <div class="description">
                     <localize key="FALM_LogsManager.Description_TL">With this tool you can view the Umbraco Trace Logs events</localize>
                 </div>
@@ -24,7 +24,7 @@
                             <umb-load-indicator></umb-load-indicator>
                         </div>
                         
-                        <div ng-hide="!logs.ListTraceLogs.length" class="panel panel-primary">
+                        <div ng-hide="!logs.ListTraceLogs.length" class="panel panel-default">
                             <div class="panel-heading">
                                 <localize key="FALM_LogsManager.TraceLogsPanelTitle">Trace Log</localize> <strong><i>"{{ id }}"</i></strong> <localize key="FALM_LogsManager.Contains">contains</localize> <span class="badge">{{ filteredLogs.length }}</span> <localize key="FALM_LogsManager.Events">events</localize>
                             </div>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/media-cleanup.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/media-cleanup.html
@@ -13,7 +13,7 @@
         </umb-header>
         <umb-content id="falm-content">
             <div class="umb-panel-body with-header umb-scrollable no-footer" style="padding: 0 20px; margin-top: 19px;">
-                <h2 class="title"><localize key="FALM_MediaManager.Title">Media Folders Manager (File System)</localize></h2>
+                <h3 class="title"><localize key="FALM_MediaManager.Title">Media Folders Manager (File System)</localize></h3>
                 <div class="description">
                     <localize key="FALM_MediaManager.Cleanup.Description">With this tool you can delete file system folders under '/media' which have no entry in the DB (orphans).</localize>
                 </div>
@@ -26,9 +26,9 @@
                         </div>
                         
                         <div ng-hide="!media.ListMediaWarnings.length" class="mediaWarningsForm">
-                            <div class="panel panel-primary">
+                            <div class="panel panel-default">
                                 <div class="panel-heading">
-                                    <localize key="FALM_MediaManager.Cleanup.WarningsPanelTitle">Informations</localize>
+                                    <span class="bold"><localize key="FALM_MediaManager.Cleanup.WarningsPanelTitle">Informations</localize></span>
                                 </div>
                                 <div class="panel-body">
                                     <div><localize key="FALM_MediaManager.Cleanup.WarningsPanelDescription">The following folders will not be deleted</localize></div>
@@ -53,7 +53,7 @@
                         <div ng-hide="!media.ListMediaToDelete.length" class="mediaToDeleteForm">
                             <div class="panel panel-danger">
                                 <div class="panel-heading">
-                                    <localize key="FALM_MediaManager.Cleanup.OrphansPanelTitle">Cleanup</localize>
+                                    <span class="bold"><localize key="FALM_MediaManager.Cleanup.OrphansPanelTitle">Cleanup</localize></span>
                                 </div>
                                 <div class="panel-body">
                                     <div><localize key="FALM_MediaManager.Cleanup.OrphansPanelDescription">The following folders can be deleted</localize></div>
@@ -88,7 +88,7 @@
                         <div ng-hide="!showNoMediaOrphans" class="noMediaToDelete">
                             <div class="panel panel-danger">
                                 <div class="panel-heading">
-                                    <localize key="FALM_MediaManager.Cleanup.OrphansPanelTitle">Cleanup</localize>
+                                    <span class="bold"><localize key="FALM_MediaManager.Cleanup.OrphansPanelTitle">Cleanup</localize></span>
                                 </div>
                                 <div class="panel-body">
                                     <p><localize key="FALM_MediaManager.Cleanup.NoMediaToDelete">There are no media to delete.</localize></p>
@@ -110,9 +110,9 @@
 
                         
                         <div ng-hide="!media.ListMediaWarnings.length" class="mediaWarningsForm">
-                            <div class="panel panel-primary">
+                            <div class="panel panel-default">
                                 <div class="panel-heading">
-                                    <localize key="FALM_MediaManager.Cleanup.WarningsPanelTitle">Informations</localize>
+                                    <span class="bold"><localize key="FALM_MediaManager.Cleanup.WarningsPanelTitle">Informations</localize></span>
                                 </div>
                                 <div class="panel-body">
                                     <div><localize key="FALM_MediaManager.Cleanup.WarningsPanelDescriptionResults">The following folders haven't been deleted</localize></div>
@@ -137,7 +137,7 @@
                         <div ng-hide="!media.ListMediaToDelete.length" class="mediaToDeleteForm">
                             <div class="panel panel-danger">
                                 <div class="panel-heading">
-                                    <localize key="FALM_MediaManager.Cleanup.OrphansPanelTitle">File System Cleanup</localize>
+                                    <span class="bold"><localize key="FALM_MediaManager.Cleanup.OrphansPanelTitle">File System Cleanup</localize></span>
                                 </div>
                                 <div class="panel-body">
                                     <div><localize key="FALM_MediaManager.Cleanup.OrphansPanelDescriptionResults">The following folders have been deleted</localize></div>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/users-cleanup.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/users-cleanup.html
@@ -13,16 +13,16 @@
         </umb-header>
         <umb-content id="falm-content">
             <div class="umb-panel-body with-header umb-scrollable no-footer" style="padding: 0 20px; margin-top: 19px;">
-                <h2 class="title"><localize key="FALM_UsersManager.Title">Users Manager</localize> - <localize key="FALM_UsersManager.Cleanup.SubTitle">Cleanup</localize></h2>
+                <h3 class="title"><localize key="FALM_UsersManager.Title">Users Manager</localize> - <localize key="FALM_UsersManager.Cleanup.SubTitle">Cleanup</localize></h3>
                 <div class="description">
                     <localize key="FALM_UsersManager.Cleanup.Description">With this tool you can delete one or more users</localize>
                 </div>
                 <div ng-switch="id">
                     <div ng-hide="!users.length" class="userForm">
                         <form id="deleteUsersForm" ng-submit="deleteSelectedUsers(users)" role="form">
-                            <div class="panel panel-primary">
+                            <div class="panel panel-default">
                                 <div class="panel-heading">
-                                    <localize key="FALM_UsersManager.Cleanup.UsersPanelTitle">Users</localize>
+                                    <span class="bold"><localize key="FALM_UsersManager.Cleanup.UsersPanelTitle">Users</localize></span>
                                 </div>
                                 <div class="panel-body">
                                     <p><localize key="FALM_UsersManager.Cleanup.UsersPanelDescription">The following users can be deleted</localize></p>
@@ -61,9 +61,9 @@
                     </div>
 
                     <div ng-hide="users.length" class="noUserToDelete">
-                        <div class="panel panel-primary">
+                        <div class="panel panel-default">
                             <div class="panel-heading">
-                                <localize key="FALM_UsersManager.Cleanup.UsersPanelTitle">Users</localize>
+                                <span class="bold"><localize key="FALM_UsersManager.Cleanup.UsersPanelTitle">Users</localize></span>
                             </div>
                             <div class="panel-body">
                                 <p><localize key="FALM_UsersManager.Cleanup.NoUsersToDelete">There are no users to delete.</localize></p>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager-modal-cleanupbycount.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager-modal-cleanupbycount.html
@@ -4,10 +4,10 @@
     </div>
     <div class="umb-panel-body with-header with-footer" id="falm-content">
         <div ng-hide="!dialogData.showCleanupForm" class="loading">
-            <h5>
+            <p>
                 <localize key="FALM_VersionsManager.CleanupByCount.Dialog-Description">With this tool you can cleanup the version history, keeping a given number of versions for each content node.<br />Please note that Umbraco requires each node to have at least 2 versions (the currently published and the newest). These versions will never be deleted.</localize>
-            </h5>
-        
+            </p>
+            
             <form id="versionsCleanupByCount" ng-submit="deleteVersionsByCount(dialogData.versionsToKeep)" class="form-inline" style="margin: 0 10px 0 0;">
                 <div class="form-group">
                     <label for="versionsToKeep"><localize key="FALM_VersionsManager.CleanupByCount.Dialog-VersionsCount">Number of versions to keep</localize></label><br />

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager-modal-details.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager-modal-details.html
@@ -1,11 +1,11 @@
 ﻿<umb-panel ng-controller="FALMHousekeepingVersionsManagerDetailsController">
     <div class="umb-panel-header" id="falm-header">
-        <h3 class="title"><localize key="FALM_VersionsManager.Dialog-Title">Version details</localize> (<strong>Id: {{ dialogData.currentPublishedVersionItem.NodeId }}</strong>)</h3>
+        <h3 class="title"><localize key="FALM_VersionsManager.Dialog-Title">Version details</localize> (<span>Id: {{ dialogData.currentPublishedVersionItem.NodeId }}</span>)</h3>
     </div>
     <div class="umb-panel-body with-header with-footer" id="falm-content">
         <div ng-hide="!dialogData.showCleanupForm" class="loading">
-            <table id="FHDetailsTable" class="table" style="">
-                <tbody style="font-size: 12px;">
+            <table id="FHDetailsTable" class="table">
+                <tbody>
                     <tr>
                         <th style="padding: 15px; border-top: 0; width: 120px;"><localize key="FALM_VersionsManager.Dialog-NodeName">Node name:</localize></th>
                         <td style="padding: 15px; border-top: 0;">{{ dialogData.currentPublishedVersionItem.NodeName }}</td>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager.html
@@ -13,7 +13,7 @@
         </umb-header>
         <umb-content id="falm-content">
             <div class="umb-panel-body with-header umb-scrollable no-footer" style="padding: 0 20px; margin-top: 19px;">
-                <h2 class="title"><localize key="FALM_VersionsManager.Title">Umbraco Versions Manager</localize></h2>
+                <h3 class="title"><localize key="FALM_VersionsManager.Title">Umbraco Versions Manager</localize></h3>
                 <div class="description">
                     <localize key="FALM_VersionsManager.Description">With this tool you can manage the Umbraco history versions.</localize>
                 </div>
@@ -24,7 +24,7 @@
                             <umb-load-indicator></umb-load-indicator>
                         </div>
                     </div>
-                    <div class="panel panel-primary">
+                    <div class="panel panel-default">
                         <div class="panel-heading">
                             <localize key="FALM_VersionsManager.VersionsPanelTitle">Versions panel</localize>
                         </div>
@@ -68,8 +68,7 @@
                                                 <localize key="FALM_VersionsManager.NodeName">Node Name</localize>
                                             </th>
                                             <th class="text-center" style="vertical-align: middle;">
-                                                <localize key="FALM_VersionsManager.CurrentPublishedVersionDate">Published Version</localize><br />
-                                                <span style="font-size: small; color: darkgray">(dd/MM/yyyy HH:mm:ss)</span>
+                                                <localize key="FALM_VersionsManager.CurrentPublishedVersionDate">Published Version</localize>
                                             </th>
                                             <th class="text-center" style="vertical-align: middle;">
                                                 <localize key="FALM_VersionsManager.TotalVersions">Other versions</localize>

--- a/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager.html
+++ b/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/view/versions-manager.html
@@ -26,7 +26,7 @@
                     </div>
                     <div class="panel panel-default">
                         <div class="panel-heading">
-                            <localize key="FALM_VersionsManager.VersionsPanelTitle">Versions panel</localize>
+                            <span class="bold"><localize key="FALM_VersionsManager.VersionsPanelTitle">Versions</localize></span>
                         </div>
                         <div class="panel-body">
                             <div ng-hide="!showVersions">

--- a/FALMHousekeeping/App_Plugins/FALM/lang/en-GB.xml
+++ b/FALMHousekeeping/App_Plugins/FALM/lang/en-GB.xml
@@ -13,7 +13,7 @@
     <key alias="Dashboard.VersionHistory"><![CDATA[<p><span class="title">Version History</span></p><p class="text">v7.6.0.0 - For Umbraco v7.5+</p><p class="text">v7.0.0.1 - For Umbraco v7+</p><p class="text">v6.1.3.0 - For Umbraco v6 to v7.2</p><p class="text">v4.11.0.2 - For Umbraco v4.8 to v4.11</p><p class="text">v4.5.0.1  - For Umbraco v4.5 to v4.7.2</p><p class="text">v1.1.0.0  - For Umbraco v3 to v4.0</p>]]></key>
 
     <!-- LOGS MANAGER -->
-    <key alias="LogsManager.TreeSection"><![CDATA[LOG]]></key>
+    <key alias="LogsManager.TreeSection"><![CDATA[Log]]></key>
     <key alias="LogsManager.TreeActionManagerDB"><![CDATA[DB events]]></key>
     <key alias="LogsManager.TreeActionManagerTL"><![CDATA[Trace Log]]></key>
     <key alias="LogsManager.TreeActionManagerTL.Today"><![CDATA[Today]]></key>
@@ -87,7 +87,7 @@ Are you sure you want to continue with the deletion?]]></key>
 Please try again or contact the author of the package with the details of the error.]]></key>
 
     <!-- MEDIA MANAGER -->
-    <key alias="MediaManager.TreeSection"><![CDATA[MEDIA]]></key>
+    <key alias="MediaManager.TreeSection"><![CDATA[Media]]></key>
     <key alias="MediaManager.TreeActionCleanup"><![CDATA[File System cleanup]]></key>
     <key alias="MediaManager.Title"><![CDATA[Media Folder Management (File System)]]></key>
     <key alias="MediaManager.Cleanup.SubTitle"><![CDATA[ ]]></key>
@@ -124,7 +124,7 @@ Please try again or contact the author of the package with the details of the er
     <key alias="MediaManager.Cleanup.FooterMessage"><![CDATA[ ]]></key>
 
     <!-- USERS MANAGER -->
-    <key alias="UsersManager.TreeSection"><![CDATA[USERS]]></key>
+    <key alias="UsersManager.TreeSection"><![CDATA[Users]]></key>
     <key alias="UsersManager.TreeActionCleanup"><![CDATA[Cleanup users]]></key>
     <key alias="UsersManager.Title"><![CDATA[Users Manager]]></key>
     <key alias="UsersManager.Cleanup.UsersPanelTitle"><![CDATA[Users]]></key>
@@ -154,7 +154,7 @@ Please try again or contact the author of the package with the details of the er
     <key alias="UsersManager.User.UserType"><![CDATA[User type]]></key>
 
     <!-- VERSIONS MANAGER -->
-    <key alias="VersionsManager.TreeSection"><![CDATA[VERSIONS]]></key>
+    <key alias="VersionsManager.TreeSection"><![CDATA[Versions]]></key>
     <key alias="VersionsManager.TreeActionManager"><![CDATA[Versions manager]]></key>
     <key alias="VersionsManager.Title"><![CDATA[Umbraco Versions Manager]]></key>
     <key alias="VersionsManager.SubTitle"><![CDATA[ ]]></key>

--- a/FALMHousekeeping/App_Plugins/FALM/lang/en-GB.xml
+++ b/FALMHousekeeping/App_Plugins/FALM/lang/en-GB.xml
@@ -160,7 +160,7 @@ Please try again or contact the author of the package with the details of the er
     <key alias="VersionsManager.SubTitle"><![CDATA[ ]]></key>
     <key alias="VersionsManager.Description"><![CDATA[With this tool you can manage the Umbraco history versions.]]></key>
     <key alias="VersionsManager.SearchInProgress"><![CDATA[Search in progress. Please wait until you see results]]></key>
-    <key alias="VersionsManager.VersionsPanelTitle"><![CDATA[Versions panel]]></key>
+    <key alias="VersionsManager.VersionsPanelTitle"><![CDATA[Versions]]></key>
     <key alias="VersionsManager.FilterByNodeId"><![CDATA[Filter by node Id]]></key>
     <key alias="VersionsManager.FilterByNodeName"><![CDATA[Filter by node name]]></key>
     <key alias="VersionsManager.FilterByDateFrom"><![CDATA[Filter by date range (from)]]></key>

--- a/FALMHousekeeping/App_Plugins/FALM/lang/en-US.xml
+++ b/FALMHousekeeping/App_Plugins/FALM/lang/en-US.xml
@@ -13,7 +13,7 @@
     <key alias="Dashboard.VersionHistory"><![CDATA[<p><span class="title">Version History</span></p><p class="text">v7.6.0.0 - For Umbraco v7.5+</p><p class="text">v7.0.0.1 - For Umbraco v7+</p><p class="text">v6.1.3.0 - For Umbraco v6 to v7.2</p><p class="text">v4.11.0.2 - For Umbraco v4.8 to v4.11</p><p class="text">v4.5.0.1  - For Umbraco v4.5 to v4.7.2</p><p class="text">v1.1.0.0  - For Umbraco v3 to v4.0</p>]]></key>
 
     <!-- LOGS MANAGER -->
-    <key alias="LogsManager.TreeSection"><![CDATA[LOG]]></key>
+    <key alias="LogsManager.TreeSection"><![CDATA[Log]]></key>
     <key alias="LogsManager.TreeActionManagerDB"><![CDATA[DB events]]></key>
     <key alias="LogsManager.TreeActionManagerTL"><![CDATA[Trace Log]]></key>
     <key alias="LogsManager.TreeActionManagerTL.Today"><![CDATA[Today]]></key>
@@ -87,7 +87,7 @@ Are you sure you want to continue with the deletion?]]></key>
 Please try again or contact the author of the package with the details of the error.]]></key>
 
     <!-- MEDIA MANAGER -->
-    <key alias="MediaManager.TreeSection"><![CDATA[MEDIA]]></key>
+    <key alias="MediaManager.TreeSection"><![CDATA[Media]]></key>
     <key alias="MediaManager.TreeActionCleanup"><![CDATA[File System cleanup]]></key>
     <key alias="MediaManager.Title"><![CDATA[Media Folder Management (File System)]]></key>
     <key alias="MediaManager.Cleanup.SubTitle"><![CDATA[ ]]></key>
@@ -122,7 +122,7 @@ Please try again or contact the author of the package with the details of the er
     <key alias="MediaManager.Cleanup.FooterMessage"><![CDATA[ ]]></key>
 
     <!-- USERS MANAGER -->
-    <key alias="UsersManager.TreeSection"><![CDATA[USERS]]></key>
+    <key alias="UsersManager.TreeSection"><![CDATA[Users]]></key>
     <key alias="UsersManager.TreeActionCleanup"><![CDATA[Cleanup users]]></key>
     <key alias="UsersManager.Title"><![CDATA[Users Manager]]></key>
     <key alias="UsersManager.Cleanup.UsersPanelTitle"><![CDATA[Users]]></key>
@@ -150,7 +150,7 @@ Please try again or contact the author of the package with the details of the er
     <key alias="UsersManager.User.UserType"><![CDATA[User type]]></key>
 
     <!-- VERSIONS MANAGER -->
-    <key alias="VersionsManager.TreeSection"><![CDATA[VERSIONS]]></key>
+    <key alias="VersionsManager.TreeSection"><![CDATA[Versions]]></key>
     <key alias="VersionsManager.TreeActionManager"><![CDATA[Versions manager]]></key>
     <key alias="VersionsManager.Title"><![CDATA[Umbraco Versions Manager]]></key>
     <key alias="VersionsManager.SubTitle"><![CDATA[ ]]></key>

--- a/FALMHousekeeping/App_Plugins/FALM/lang/en-US.xml
+++ b/FALMHousekeeping/App_Plugins/FALM/lang/en-US.xml
@@ -156,7 +156,7 @@ Please try again or contact the author of the package with the details of the er
     <key alias="VersionsManager.SubTitle"><![CDATA[ ]]></key>
     <key alias="VersionsManager.Description"><![CDATA[With this tool you can manage the Umbraco history versions.]]></key>
     <key alias="VersionsManager.SearchInProgress"><![CDATA[Search in progress. Please wait until you see results]]></key>
-    <key alias="VersionsManager.VersionsPanelTitle"><![CDATA[Versions panel]]></key>
+    <key alias="VersionsManager.VersionsPanelTitle"><![CDATA[Versions]]></key>
     <key alias="VersionsManager.FilterByNodeId"><![CDATA[Filter by node Id]]></key>
     <key alias="VersionsManager.FilterByNodeName"><![CDATA[Filter by node name]]></key>
     <key alias="VersionsManager.FilterByDateFrom"><![CDATA[Filter by date range (from)]]></key>

--- a/FALMHousekeeping/App_Plugins/FALM/lang/it-IT.xml
+++ b/FALMHousekeeping/App_Plugins/FALM/lang/it-IT.xml
@@ -13,7 +13,7 @@
     <key alias="Dashboard.VersionHistory"><![CDATA[<p><span class="title">Version History</span></p><p class="text">v7.6.0.0 - For Umbraco v7.5+</p><p class="text">v7.0.0.1 - For Umbraco v7+</p><p class="text">v6.1.3.0 - For Umbraco v6 to v7.2</p><p class="text">v4.11.0.2 - For Umbraco v4.8 to v4.11</p><p class="text">v4.5.0.1  - For Umbraco v4.5 to v4.7.2</p><p class="text">v1.1.0.0  - For Umbraco v3 to v4.0</p>]]></key>
 
     <!-- LOGS MANAGER -->
-    <key alias="LogsManager.TreeSection"><![CDATA[LOG]]></key>
+    <key alias="LogsManager.TreeSection"><![CDATA[Log]]></key>
     <key alias="LogsManager.TreeActionManagerDB"><![CDATA[Eventi sul DB]]></key>
     <key alias="LogsManager.TreeActionManagerTL"><![CDATA[Trace Log]]></key>
     <key alias="LogsManager.TreeActionManagerTL.Today"><![CDATA[Oggi]]></key>
@@ -87,7 +87,7 @@ Sei sicuro di voler proseguire con la cancellazione?]]></key>
 Si prega di riprovare o di contattare l'autore del package indicando i dettagli dell'errore."]]></key>
     
     <!-- MEDIA MANAGER -->
-    <key alias="MediaManager.TreeSection"><![CDATA[MEDIA]]></key>
+    <key alias="MediaManager.TreeSection"><![CDATA[Media]]></key>
     <key alias="MediaManager.TreeActionCleanup"><![CDATA[Pulizia del File System]]></key>
     <key alias="MediaManager.Title"><![CDATA[Gestione Cartelle Media (File System)]]></key>
     <key alias="MediaManager.Cleanup.SubTitle"><![CDATA[ ]]></key>
@@ -121,7 +121,7 @@ Si prega di riprovare oppure contattare l'autore indicando i dettagli dell'error
     <key alias="MediaManager.Cleanup.FooterMessage"><![CDATA[ ]]></key>
 
     <!-- USERS MANAGER -->
-    <key alias="UsersManager.TreeSection"><![CDATA[UTENTI]]></key>
+    <key alias="UsersManager.TreeSection"><![CDATA[Utenti]]></key>
     <key alias="UsersManager.TreeActionCleanup"><![CDATA[Cancellazione utenti]]></key>
     <key alias="UsersManager.Title"><![CDATA[Gestione Utenti]]></key>
     <key alias="UsersManager.Cleanup.UsersPanelTitle"><![CDATA[Utenti]]></key>
@@ -149,7 +149,7 @@ Si prega di riprovare o di contattare l'autore del package indicando i dettagli 
     <key alias="UsersManager.User.UserType"><![CDATA[Tipo di utente]]></key>
 
     <!-- VERSIONS MANAGER -->
-    <key alias="VersionsManager.TreeSection"><![CDATA[VERSIONI]]></key>
+    <key alias="VersionsManager.TreeSection"><![CDATA[Versioni]]></key>
     <key alias="VersionsManager.TreeActionManager"><![CDATA[Gestione delle versioni]]></key>
     <key alias="VersionsManager.Title"><![CDATA[Gestione Versioni]]></key>
     <key alias="VersionsManager.SubTitle"><![CDATA[ ]]></key>

--- a/FALMHousekeeping/Constants/HKConstants.cs
+++ b/FALMHousekeeping/Constants/HKConstants.cs
@@ -15,7 +15,7 @@
             /// <summary>Alias of the Application</summary>
             public const string Alias = "FALM";
             /// <summary>Icon of the Application</summary>
-            public const string Icon = "icon-speed-gauge color-yellow";
+            public const string Icon = "icon-speed-gauge";
             /// <summary>Title of the Application</summary>
             public const string Title = "F.A.L.M. Housekeeping";
         }


### PR DESCRIPTION
I have fixed a few of the mentioned things in https://github.com/FALM-Umbraco-Projects/FALM-Housekeeping-v7/issues/31

I also noticed the the loading indicator is never shown in Log > DB events because when the `showLoader` property to  `false` immediately after you set it to true. You set set it to true before you get the response. On large sites this takes several seconds before it get the response.
https://github.com/FALM-Umbraco-Projects/FALM-Housekeeping-v7/blob/afeb80a7787a40570fc284ac7b8fc225c6c9f190/FALMHousekeeping/App_Plugins/FALM/backoffice/housekeeping/controller/logs.controller.js#L35-L51

On a large multiside solution I see this for about 10 seconds before getting the response and seeing the table data.

![image](https://user-images.githubusercontent.com/2919859/31580202-e65d7fe0-b148-11e7-9b3a-924e50a3ea5d.png)